### PR TITLE
Skiplink per saltare ai contenuti principali della pagina

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { Link } from 'gatsby'
 import classNames from 'classnames'
 
+import SkipLink from './skiplink'
 import Logo from '../assets/icons/logo'
 import Brand from '../assets/icons/brand'
 
@@ -56,14 +57,17 @@ const Header = () => {
 
   return (
     <header className="cp-header">
-      <Link to="/" className="cp-header__logo" aria-label='Link alla home'>
-        <div className="cp-header__logo-image">
-          <Logo />
-        </div>
-        <div className="cp-header__logo-brand">
-          <Brand />
-        </div>
-      </Link>
+      <div className="cp-header__links">
+        <SkipLink />
+        <Link to="/" className="cp-header__logo" aria-label='Link alla home'>
+          <div className="cp-header__logo-image">
+            <Logo />
+          </div>
+          <div className="cp-header__logo-brand">
+            <Brand />
+          </div>
+        </Link>
+      </div>
       <button 
         className={burgerClass} 
         onClick={click}

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -29,7 +29,7 @@ const Layout = ({ children }) => {
       <div className="headquarter">
         <Header siteTitle={data.site.siteMetadata.title} />
         <div>
-          <main>{children}</main>
+          <main id="content">{children}</main>
         </div>
         <Footer />
       </div>

--- a/src/components/skiplink.js
+++ b/src/components/skiplink.js
@@ -1,0 +1,7 @@
+import React from 'react'
+
+const SkipLink = () => (
+  <a className="skiplink" href="#content">Vai al contenuto</a>
+)
+
+export default SkipLink

--- a/src/components/skiplink.js
+++ b/src/components/skiplink.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 const SkipLink = () => (
-  <a className="skiplink" href="#content">Vai al contenuto</a>
+  <a className="cp-header__skiplink" href="#content">Vai al contenuto</a>
 )
 
 export default SkipLink

--- a/src/scss/_header.scss
+++ b/src/scss/_header.scss
@@ -38,6 +38,25 @@ $prefix: cp-header;
     }
   }
 
+  &__links{
+    display: flex;
+    flex-direction: row-reverse;
+    align-items: center;
+    justify-content: start;
+    gap: 0.5rem;
+  }
+
+  &__skiplink {
+    position: relative;
+    top: -1000px;
+    padding: 0.2rem;
+    font-size: 1rem;
+  }
+
+  &__skiplink:focus-visible {
+    top: -0.1rem;
+  }
+
   &__burger{
     background: transparent;
     border: none;
@@ -134,7 +153,7 @@ $prefix: cp-header;
         height: 0;
         overflow: hidden;
         visibility: hidden;
-    }
+      }
     }
   }
 }


### PR DESCRIPTION
Lo [skiplink](https://en.wikipedia.org/wiki/Skip_link) è il primo elemento di una pagina web che riceve il focus quando si preme il tasto `Tab`. Fornisce un collegamento ai contenuti principali della pagina e per questo aiuta gli utenti con disabilità visive (o che usano la tastiera come principale mezzo di navigazione) a saltare direttamente alla parte interessante di una pagina.

Lo skiplink è inizialmente nascosto (non con `display: none`, altrimenti non potrebbe ricevere il focus) e diventa visibile solo se l'utente usa il tasto `Tab`. A quel punto può premere `Invio` per saltare ai contenuti di pagina, saltando quindi gli altri elementi della header (nel nostro caso: il menu di navigazione).



<img width="800" height="461" alt="skiplink" src="https://github.com/user-attachments/assets/b979587e-ec66-41dd-9f9b-16ea707bcdbf" />
